### PR TITLE
Add support for opcode aliases

### DIFF
--- a/sfzero/SFZReader.cpp
+++ b/sfzero/SFZReader.cpp
@@ -263,7 +263,7 @@ void sfzero::Reader::read(const char *text, unsigned int length)
           {
             buildingRegion->group = static_cast<int>(value.getLargeIntValue());
           }
-          else if (opcode == "off_by")
+          else if (opcode == "off_by" || opcode == "offby")
           {
             buildingRegion->off_by = value.getLargeIntValue();
           }
@@ -283,7 +283,7 @@ void sfzero::Reader::read(const char *text, unsigned int length)
               buildingRegion->end = end2;
             }
           }
-          else if (opcode == "loop_mode")
+          else if (opcode == "loop_mode" || opcode == "loopmode")
           {
             bool modeIsSupported = value == "no_loop" || value == "one_shot" || value == "loop_continuous";
             if (modeIsSupported)
@@ -296,11 +296,11 @@ void sfzero::Reader::read(const char *text, unsigned int length)
               sound_->addUnsupportedOpcode(fauxOpcode);
             }
           }
-          else if (opcode == "loop_start")
+          else if (opcode == "loop_start" || opcode == "loopstart")
           {
             buildingRegion->loop_start = value.getLargeIntValue();
           }
-          else if (opcode == "loop_end")
+          else if (opcode == "loop_end" || opcode == "loopend")
           {
             buildingRegion->loop_end = value.getLargeIntValue();
           }
@@ -320,11 +320,11 @@ void sfzero::Reader::read(const char *text, unsigned int length)
           {
             buildingRegion->pitch_keytrack = value.getIntValue();
           }
-          else if (opcode == "bend_up")
+          else if (opcode == "bend_up" || opcode == "bendup")
           {
             buildingRegion->bend_up = value.getIntValue();
           }
-          else if (opcode == "bend_down")
+          else if (opcode == "bend_down" || opcode == "benddown")
           {
             buildingRegion->bend_down = value.getIntValue();
           }


### PR DESCRIPTION
Opcode aliases are listed here: https://www.linuxsampler.org/sfz/

Not sure which implementations use them, but at the very least ChickenSys Translator outputs loopstart and loopend in its generated SFZ