### PR TITLE
Override unsigned->signed cast warnings

### DIFF
--- a/sfzero/SF2.cpp
+++ b/sfzero/SF2.cpp
@@ -93,7 +93,7 @@ void sfzero::SF2::Hydra::readFrom(juce::InputStream *file, juce::int64 pdtaChunk
 #define HandleChunk(chunkName)                                                                                                   \
   if (FourCCEquals(chunk.id, #chunkName))                                                                                        \
   {                                                                                                                              \
-    numItems = chunk.size / SF2::chunkName::sizeInFile;                                                                          \
+    numItems = static_cast<int>(chunk.size / SF2::chunkName::sizeInFile);                                                                          \
     chunkName##NumItems = numItems;                                                                                              \
     chunkName##Items = new SF2::chunkName[numItems];                                                                             \
     for (i = 0; i < numItems; ++i)                                                                                               \

--- a/sfzero/SF2Reader.cpp
+++ b/sfzero/SF2Reader.cpp
@@ -222,7 +222,7 @@ juce::AudioSampleBuffer *sfzero::SF2Reader::readSamples(double *progressVar, juc
   }
 
   // Allocate the AudioSampleBuffer.
-  int numSamples = chunk.size / sizeof(short);
+  int numSamples = static_cast<int>(chunk.size / sizeof(short));
   juce::AudioSampleBuffer *sampleBuffer = new juce::AudioSampleBuffer(1, numSamples);
 
   // Read and convert.


### PR DESCRIPTION
Exactly what it says in the title. Fixes some minor signed/unsigned cast warnings via `static_cast`. Doesn't appear to have any side effects under normal usage.