### PR TITLE
small fixes for compiling with JUCE 5.4.7

### DIFF
--- a/sfzero/SFZReader.cpp
+++ b/sfzero/SFZReader.cpp
@@ -490,7 +490,7 @@ const char *sfzero::Reader::readPathInto(juce::String *pathOut, const char *pIn,
   }
   else
   {
-    *pathOut = juce::String::empty;
+    *pathOut = juce::String();
   }
   return p;
 }
@@ -546,11 +546,11 @@ int sfzero::Reader::triggerValue(const juce::String &str)
   {
     return sfzero::Region::release;
   }
-  if (str == "first")
+  else if (str == "first")
   {
     return sfzero::Region::first;
   }
-  if (str == "legato")
+  else if (str == "legato")
   {
     return sfzero::Region::legato;
   }
@@ -563,15 +563,15 @@ int sfzero::Reader::loopModeValue(const juce::String &str)
   {
     return sfzero::Region::no_loop;
   }
-  if (str == "one_shot")
+  else if (str == "one_shot")
   {
     return sfzero::Region::one_shot;
   }
-  if (str == "loop_continuous")
+  else if (str == "loop_continuous")
   {
     return sfzero::Region::loop_continuous;
   }
-  if (str == "loop_sustain")
+  else if (str == "loop_sustain")
   {
     return sfzero::Region::loop_sustain;
   }

--- a/sfzero/SFZSound.cpp
+++ b/sfzero/SFZSound.cpp
@@ -134,7 +134,7 @@ sfzero::Region *sfzero::Sound::regionAt(int index) { return regions_[index]; }
 
 int sfzero::Sound::numSubsounds() { return 1; }
 
-juce::String sfzero::Sound::subsoundName(int /*whichSubsound*/) { return juce::String::empty; }
+juce::String sfzero::Sound::subsoundName(int /*whichSubsound*/) { return juce::String(); }
 
 void sfzero::Sound::useSubsound(int /*whichSubsound*/) {}
 

--- a/sfzero/SFZSound.h
+++ b/sfzero/SFZSound.h
@@ -17,7 +17,7 @@ class Sample;
 class Sound : public juce::SynthesiserSound
 {
 public:
-  explicit Sound(const juce::File &file);
+  Sound(const juce::File &file);
   virtual ~Sound();
 
   typedef juce::ReferenceCountedObjectPtr<Sound> Ptr;
@@ -26,7 +26,7 @@ public:
   bool appliesToChannel(int midiChannel) override;
 
   void addRegion(Region *region); // Takes ownership of the region.
-  Sample *addSample(juce::String path, juce::String defaultPath = juce::String::empty);
+  Sample *addSample(juce::String path, juce::String defaultPath = juce::String());
   void addError(const juce::String &message);
   void addUnsupportedOpcode(const juce::String &opcode);
 

--- a/sfzero/SFZSynth.cpp
+++ b/sfzero/SFZSynth.cpp
@@ -21,7 +21,7 @@ void sfzero::Synth::noteOn(int midiChannel, int midiNoteNumber, float velocity)
   // First, stop any currently-playing sounds in the group.
   //*** Currently, this only pays attention to the first matching region.
   int group = 0;
-  sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0));
+  sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0).get());
 
   if (sound)
   {
@@ -107,7 +107,7 @@ void sfzero::Synth::noteOff(int midiChannel, int midiNoteNumber, float velocity,
   Synthesiser::noteOff(midiChannel, midiNoteNumber, velocity, allowTailOff);
 
   // Start release region.
-  sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0));
+  sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0).get());
   if (sound)
   {
     sfzero::Region *region = sound->getRegionFor(midiNoteNumber, noteVelocities_[midiNoteNumber], sfzero::Region::release);


### PR DESCRIPTION
As mentionned here https://github.com/stevefolta/SFZero/issues/5
small modifications are needed  in order to keep the library compiling with latest JUCE

sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0));
needs to be changed to:
sfzero::Sound *sound = dynamic_cast<sfzero::Sound *>(getSound(0).get());

occurrences of 
juce::String::empty
need to be changed to
 juce::String()